### PR TITLE
refactor: convert StateSerializable to use symbol-keyed methods

### DIFF
--- a/src/__tests__/app-state.test.ts
+++ b/src/__tests__/app-state.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it } from 'vitest'
 import { AppState } from '../app-state.js'
+import {
+  isStateSerializable,
+  loadStateFromJSON,
+  loadStateSerializable,
+  serializeStateSerializable,
+  stateToJSON,
+} from '../types/serializable.js'
 
 describe('AppState', () => {
   describe('constructor', () => {
@@ -323,25 +330,66 @@ describe('AppState', () => {
     })
   })
 
-  describe('toJSON', () => {
+  describe('stateToJSON (via symbol)', () => {
     it('returns deep copy of state', () => {
       const state = new AppState({ key1: 'value1', nested: { deep: true } })
-      const json = state.toJSON()
+      const json = state[stateToJSON]()
       expect(json).toEqual({ key1: 'value1', nested: { deep: true } })
+    })
+
+    it('can be accessed via serializeStateSerializable helper', () => {
+      const state = new AppState({ key1: 'value1' })
+      const json = serializeStateSerializable(state)
+      expect(json).toEqual({ key1: 'value1' })
     })
   })
 
-  describe('loadStateFromJson', () => {
+  describe('loadStateFromJSON (via symbol)', () => {
     it('replaces state with json data', () => {
       const state = new AppState({ old: 'data' })
-      state.loadStateFromJson({ new: 'data', count: 42 })
+      state[loadStateFromJSON]({ new: 'data', count: 42 })
       expect(state.getAll()).toEqual({ new: 'data', count: 42 })
     })
 
     it('clears state when given non-object', () => {
       const state = new AppState({ key: 'value' })
-      state.loadStateFromJson(null)
+      state[loadStateFromJSON](null)
       expect(state.getAll()).toEqual({})
+    })
+
+    it('can be accessed via loadStateSerializable helper', () => {
+      const state = new AppState({ old: 'data' })
+      loadStateSerializable(state, { new: 'data' })
+      expect(state.getAll()).toEqual({ new: 'data' })
+    })
+  })
+
+  describe('isStateSerializable', () => {
+    it('returns true for AppState instances', () => {
+      const state = new AppState()
+      expect(isStateSerializable(state)).toBe(true)
+    })
+
+    it('returns false for plain objects', () => {
+      const obj = { toJSON: () => ({}), loadStateFromJson: () => {} }
+      expect(isStateSerializable(obj)).toBe(false)
+    })
+
+    it('returns false for null', () => {
+      expect(isStateSerializable(null)).toBe(false)
+    })
+
+    it('returns false for objects with only one symbol method', () => {
+      const partial = { [stateToJSON]: () => ({}) }
+      expect(isStateSerializable(partial)).toBe(false)
+    })
+
+    it('returns true for objects implementing both symbol methods', () => {
+      const custom = {
+        [stateToJSON]: () => ({ custom: true }),
+        [loadStateFromJSON]: () => {},
+      }
+      expect(isStateSerializable(custom)).toBe(true)
     })
   })
 })

--- a/src/__tests__/app-state.test.ts
+++ b/src/__tests__/app-state.test.ts
@@ -2,10 +2,10 @@ import { describe, expect, it } from 'vitest'
 import { AppState } from '../app-state.js'
 import {
   isStateSerializable,
-  loadStateFromJSON,
+  loadStateFromJSONSymbol,
   loadStateSerializable,
   serializeStateSerializable,
-  stateToJSON,
+  stateToJSONSymbol,
 } from '../types/serializable.js'
 
 describe('AppState', () => {
@@ -330,10 +330,10 @@ describe('AppState', () => {
     })
   })
 
-  describe('stateToJSON (via symbol)', () => {
+  describe('stateToJSONSymbol (via symbol)', () => {
     it('returns deep copy of state', () => {
       const state = new AppState({ key1: 'value1', nested: { deep: true } })
-      const json = state[stateToJSON]()
+      const json = state[stateToJSONSymbol]()
       expect(json).toEqual({ key1: 'value1', nested: { deep: true } })
     })
 
@@ -344,16 +344,16 @@ describe('AppState', () => {
     })
   })
 
-  describe('loadStateFromJSON (via symbol)', () => {
+  describe('loadStateFromJSONSymbol (via symbol)', () => {
     it('replaces state with json data', () => {
       const state = new AppState({ old: 'data' })
-      state[loadStateFromJSON]({ new: 'data', count: 42 })
+      state[loadStateFromJSONSymbol]({ new: 'data', count: 42 })
       expect(state.getAll()).toEqual({ new: 'data', count: 42 })
     })
 
     it('clears state when given non-object', () => {
       const state = new AppState({ key: 'value' })
-      state[loadStateFromJSON](null)
+      state[loadStateFromJSONSymbol](null)
       expect(state.getAll()).toEqual({})
     })
 
@@ -380,14 +380,14 @@ describe('AppState', () => {
     })
 
     it('returns false for objects with only one symbol method', () => {
-      const partial = { [stateToJSON]: () => ({}) }
+      const partial = { [stateToJSONSymbol]: () => ({}) }
       expect(isStateSerializable(partial)).toBe(false)
     })
 
     it('returns true for objects implementing both symbol methods', () => {
       const custom = {
-        [stateToJSON]: () => ({ custom: true }),
-        [loadStateFromJSON]: () => {},
+        [stateToJSONSymbol]: () => ({ custom: true }),
+        [loadStateFromJSONSymbol]: () => {},
       }
       expect(isStateSerializable(custom)).toBe(true)
     })

--- a/src/agent/snapshot.ts
+++ b/src/agent/snapshot.ts
@@ -14,6 +14,7 @@
 import type { JSONValue } from '../types/json.js'
 import type { MessageData, SystemPromptData } from '../types/messages.js'
 import { Message, systemPromptFromData, systemPromptToData } from '../types/messages.js'
+import { loadStateSerializable, serializeStateSerializable } from '../types/serializable.js'
 import type { Agent } from './agent.js'
 
 /**
@@ -134,7 +135,7 @@ export function takeSnapshot(agent: Agent, options: TakeSnapshotOptions): Snapsh
   }
 
   if (fields.has('state')) {
-    data.state = agent.state.toJSON()
+    data.state = serializeStateSerializable(agent.state)
   }
 
   if (fields.has('systemPrompt')) {
@@ -176,7 +177,7 @@ export function loadSnapshot(agent: Agent, snapshot: Snapshot): void {
   }
 
   if (state !== undefined) {
-    agent.state.loadStateFromJson(state)
+    loadStateSerializable(agent.state, state)
   }
 
   // Only restore systemPrompt if explicitly present and non-null in the snapshot

--- a/src/app-state.ts
+++ b/src/app-state.ts
@@ -1,5 +1,5 @@
 import { deepCopy, deepCopyWithValidation, type JSONValue } from './types/json.js'
-import { loadStateFromJSON, stateToJSON, type StateSerializable } from './types/serializable.js'
+import { loadStateFromJSONSymbol, stateToJSONSymbol, type StateSerializable } from './types/serializable.js'
 
 /**
  * App state provides key-value storage outside conversation context.
@@ -145,7 +145,7 @@ export class AppState implements StateSerializable {
    *
    * @returns Deep copy of all state
    */
-  [stateToJSON](): JSONValue {
+  [stateToJSONSymbol](): JSONValue {
     return deepCopy(this._state) as JSONValue
   }
 
@@ -155,7 +155,7 @@ export class AppState implements StateSerializable {
    *
    * @param json - The serialized state to load
    */
-  [loadStateFromJSON](json: JSONValue): void {
+  [loadStateFromJSONSymbol](json: JSONValue): void {
     if (json !== null && typeof json === 'object' && !Array.isArray(json)) {
       this._state = deepCopy(json) as Record<string, JSONValue>
     } else {

--- a/src/app-state.ts
+++ b/src/app-state.ts
@@ -1,5 +1,5 @@
 import { deepCopy, deepCopyWithValidation, type JSONValue } from './types/json.js'
-import type { StateSerializable } from './types/serializable.js'
+import { loadStateFromJSON, stateToJSON, type StateSerializable } from './types/serializable.js'
 
 /**
  * App state provides key-value storage outside conversation context.
@@ -141,19 +141,21 @@ export class AppState implements StateSerializable {
 
   /**
    * Returns the serialized state as JSON value.
+   * This is an internal method accessed via symbol.
    *
    * @returns Deep copy of all state
    */
-  toJSON(): JSONValue {
+  [stateToJSON](): JSONValue {
     return deepCopy(this._state) as JSONValue
   }
 
   /**
    * Loads state from a previously serialized JSON value.
+   * This is an internal method accessed via symbol.
    *
    * @param json - The serialized state to load
    */
-  loadStateFromJson(json: JSONValue): void {
+  [loadStateFromJSON](json: JSONValue): void {
     if (json !== null && typeof json === 'object' && !Array.isArray(json)) {
       this._state = deepCopy(json) as Record<string, JSONValue>
     } else {

--- a/src/session/__tests__/session-manager.test.ts
+++ b/src/session/__tests__/session-manager.test.ts
@@ -11,7 +11,7 @@ import {
 import { Agent } from '../../agent/agent.js'
 import { Message, TextBlock } from '../../types/messages.js'
 import { createMockAgent as createMockAgentWithHooks, invokeTrackedHook } from '../../__fixtures__/agent-helpers.js'
-import { loadStateFromJSON, stateToJSON } from '../../types/serializable.js'
+import { loadStateFromJSONSymbol, stateToJSONSymbol } from '../../types/serializable.js'
 
 // Test fixtures
 function createMockAgent(id = 'agent'): Agent {
@@ -26,10 +26,10 @@ function createMockAgent(id = 'agent'): Agent {
       set(k: string, v: unknown) {
         this._m.set(k, v)
       },
-      [stateToJSON]() {
+      [stateToJSONSymbol]() {
         return Object.fromEntries(this._m)
       },
-      [loadStateFromJSON](json: Record<string, unknown>) {
+      [loadStateFromJSONSymbol](json: Record<string, unknown>) {
         Object.entries(json).forEach(([k, v]) => this._m.set(k, v))
       },
     } as any,

--- a/src/session/__tests__/session-manager.test.ts
+++ b/src/session/__tests__/session-manager.test.ts
@@ -11,6 +11,7 @@ import {
 import { Agent } from '../../agent/agent.js'
 import { Message, TextBlock } from '../../types/messages.js'
 import { createMockAgent as createMockAgentWithHooks, invokeTrackedHook } from '../../__fixtures__/agent-helpers.js'
+import { loadStateFromJSON, stateToJSON } from '../../types/serializable.js'
 
 // Test fixtures
 function createMockAgent(id = 'agent'): Agent {
@@ -25,10 +26,10 @@ function createMockAgent(id = 'agent'): Agent {
       set(k: string, v: unknown) {
         this._m.set(k, v)
       },
-      toJSON() {
+      [stateToJSON]() {
         return Object.fromEntries(this._m)
       },
-      loadStateFromJson(json: Record<string, unknown>) {
+      [loadStateFromJSON](json: Record<string, unknown>) {
         Object.entries(json).forEach(([k, v]) => this._m.set(k, v))
       },
     } as any,

--- a/src/types/serializable.ts
+++ b/src/types/serializable.ts
@@ -3,25 +3,44 @@
  *
  * This module provides interfaces for objects that can serialize and deserialize
  * their state, enabling persistence and restoration of runtime state.
+ *
+ * StateSerializable uses symbol-keyed methods to keep the serialization API internal,
+ * preventing accidental usage by customers (e.g., accessing agent.state.toJSON() directly).
  */
 
-import type { JSONSerializable } from './json.js'
 import type { JSONValue } from './json.js'
 
 /**
+ * Symbol for the serialization method on StateSerializable objects.
+ */
+export const stateToJSON = Symbol('StateSerializable.toJSON')
+
+/**
+ * Symbol for the deserialization method on StateSerializable objects.
+ */
+export const loadStateFromJSON = Symbol('StateSerializable.loadStateFromJSON')
+
+/**
  * Interface for mutable state containers that can serialize and restore their state.
- * Extends JSONSerializable for one-way serialization, adding in-place state restoration.
+ * Uses symbol-keyed methods to keep the API internal.
  *
  * Use JSONSerializable for immutable value objects (with static fromJSON).
  * Use StateSerializable for mutable state that loads into an existing instance.
  */
-export interface StateSerializable extends JSONSerializable<JSONValue> {
+export interface StateSerializable {
+  /**
+   * Serializes the state to a JSON value.
+   *
+   * @returns The serialized state
+   */
+  [stateToJSON](): JSONValue
+
   /**
    * Loads state from a previously serialized JSON value.
    *
    * @param json - The serialized state to load
    */
-  loadStateFromJson(json: JSONValue): void
+  [loadStateFromJSON](json: JSONValue): void
 }
 
 /**
@@ -34,7 +53,27 @@ export function isStateSerializable(obj: unknown): obj is StateSerializable {
   return (
     obj !== null &&
     typeof obj === 'object' &&
-    typeof (obj as StateSerializable).toJSON === 'function' &&
-    typeof (obj as StateSerializable).loadStateFromJson === 'function'
+    typeof (obj as StateSerializable)[stateToJSON] === 'function' &&
+    typeof (obj as StateSerializable)[loadStateFromJSON] === 'function'
   )
+}
+
+/**
+ * Serializes a StateSerializable object to JSON.
+ *
+ * @param obj - The StateSerializable object to serialize
+ * @returns The serialized JSON value
+ */
+export function serializeStateSerializable(obj: StateSerializable): JSONValue {
+  return obj[stateToJSON]()
+}
+
+/**
+ * Loads state from JSON into a StateSerializable object.
+ *
+ * @param obj - The StateSerializable object to load state into
+ * @param json - The JSON value to load
+ */
+export function loadStateSerializable(obj: StateSerializable, json: JSONValue): void {
+  obj[loadStateFromJSON](json)
 }

--- a/src/types/serializable.ts
+++ b/src/types/serializable.ts
@@ -13,12 +13,12 @@ import type { JSONValue } from './json.js'
 /**
  * Symbol for the serialization method on StateSerializable objects.
  */
-export const stateToJSON = Symbol('StateSerializable.toJSON')
+export const stateToJSONSymbol = Symbol('StateSerializable.toJSON')
 
 /**
  * Symbol for the deserialization method on StateSerializable objects.
  */
-export const loadStateFromJSON = Symbol('StateSerializable.loadStateFromJSON')
+export const loadStateFromJSONSymbol = Symbol('StateSerializable.loadStateFromJSON')
 
 /**
  * Interface for mutable state containers that can serialize and restore their state.
@@ -33,14 +33,14 @@ export interface StateSerializable {
    *
    * @returns The serialized state
    */
-  [stateToJSON](): JSONValue
+  [stateToJSONSymbol](): JSONValue
 
   /**
    * Loads state from a previously serialized JSON value.
    *
    * @param json - The serialized state to load
    */
-  [loadStateFromJSON](json: JSONValue): void
+  [loadStateFromJSONSymbol](json: JSONValue): void
 }
 
 /**
@@ -53,8 +53,8 @@ export function isStateSerializable(obj: unknown): obj is StateSerializable {
   return (
     obj !== null &&
     typeof obj === 'object' &&
-    typeof (obj as StateSerializable)[stateToJSON] === 'function' &&
-    typeof (obj as StateSerializable)[loadStateFromJSON] === 'function'
+    typeof (obj as StateSerializable)[stateToJSONSymbol] === 'function' &&
+    typeof (obj as StateSerializable)[loadStateFromJSONSymbol] === 'function'
   )
 }
 
@@ -65,7 +65,7 @@ export function isStateSerializable(obj: unknown): obj is StateSerializable {
  * @returns The serialized JSON value
  */
 export function serializeStateSerializable(obj: StateSerializable): JSONValue {
-  return obj[stateToJSON]()
+  return obj[stateToJSONSymbol]()
 }
 
 /**
@@ -75,5 +75,5 @@ export function serializeStateSerializable(obj: StateSerializable): JSONValue {
  * @param json - The JSON value to load
  */
 export function loadStateSerializable(obj: StateSerializable, json: JSONValue): void {
-  obj[loadStateFromJSON](json)
+  obj[loadStateFromJSONSymbol](json)
 }


### PR DESCRIPTION
## Motivation

`StateSerializable` is used internally for serializing Snapshotable objects but exposes public `toJSON()` and `loadStateFromJson()` methods that customers could accidentally call (e.g., `agent.state.loadStateFromJson`). By converting to symbol-keyed methods, we keep the serialization API internal while maintaining full functionality for snapshot operations.

Resolves #46

## Public API Changes

No public API changes. This is an internal refactoring that makes `StateSerializable` methods inaccessible via string-named property access. Customers should not have been using `StateSerializable` directly.

The symbols and helper functions are intentionally NOT exported from `src/index.ts`.

```typescript
// Before: Methods accessible via string names (undesirable)
agent.state.toJSON()              // worked but shouldn't be exposed
agent.state.loadStateFromJson({}) // worked but shouldn't be exposed

// After: Methods only accessible via symbols (internal only)
agent.state[stateToJSON]()              // internal use only
agent.state[loadStateFromJSON]({})      // internal use only

// Internal code uses helper functions:
serializeStateSerializable(agent.state)       // for snapshot serialization
loadStateSerializable(agent.state, json)      // for snapshot restoration
```

## Implementation Notes

- Created symbols `stateToJSON` and `loadStateFromJSON` for internal serialization
- Removed `extends JSONSerializable` from `StateSerializable` interface
- Added helper functions `serializeStateSerializable()` and `loadStateSerializable()`
- Updated `snapshot.ts` to use helper functions instead of direct method calls
- Updated `isStateSerializable()` type guard to check for symbol-keyed methods
