### PR TITLE
feat: add barrel exports for vended-tools and vended-plugins

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -175,6 +175,7 @@ sdk-typescript/
 │   │   │   └── validation.ts
 │   │   │
 │   │   ├── vended-plugins/       # Optional vended plugins
+│   │   │   ├── index.ts          # Barrel export for all plugins
 │   │   │   ├── context-offloader/ # Context offloading plugin
 │   │   │   │   ├── __tests__/
 │   │   │   │   ├── plugin.ts
@@ -187,6 +188,7 @@ sdk-typescript/
 │   │   │       └── index.ts
 │   │   │
 │   │   ├── vended-tools/         # Optional vended tools
+│   │   │   ├── index.ts          # Barrel export for all tools
 │   │   │   ├── bash/
 │   │   │   ├── file-editor/
 │   │   │   ├── http-request/

--- a/package-lock.json
+++ b/package-lock.json
@@ -8653,6 +8653,7 @@
         "@opentelemetry/sdk-metrics": "^2.6.1",
         "@opentelemetry/sdk-trace-base": "^2.6.1",
         "@opentelemetry/sdk-trace-node": "^2.6.1",
+        "@smithy/types": "^4.0.0",
         "@types/express": "^5.0.6",
         "@types/node": "^25.6.0",
         "@types/uuid": "^11.0.0",
@@ -8688,6 +8689,7 @@
         "@opentelemetry/sdk-metrics": "^2.6.1",
         "@opentelemetry/sdk-trace-base": "^2.6.1",
         "@opentelemetry/sdk-trace-node": "^2.6.1",
+        "@smithy/types": "^4.0.0",
         "express": "^5.1.0",
         "openai": "^6.7.0",
         "zod": "^4.1.12"
@@ -8727,6 +8729,9 @@
           "optional": true
         },
         "@opentelemetry/sdk-trace-node": {
+          "optional": true
+        },
+        "@smithy/types": {
           "optional": true
         },
         "express": {

--- a/strands-ts/package.json
+++ b/strands-ts/package.json
@@ -79,6 +79,14 @@
     "./vended-plugins/context-offloader": {
       "types": "./dist/src/vended-plugins/context-offloader/index.d.ts",
       "default": "./dist/src/vended-plugins/context-offloader/index.js"
+    },
+    "./vended-tools": {
+      "types": "./dist/src/vended-tools/index.d.ts",
+      "default": "./dist/src/vended-tools/index.js"
+    },
+    "./vended-plugins": {
+      "types": "./dist/src/vended-plugins/index.d.ts",
+      "default": "./dist/src/vended-plugins/index.js"
     }
   },
   "scripts": {

--- a/strands-ts/src/vended-plugins/index.ts
+++ b/strands-ts/src/vended-plugins/index.ts
@@ -1,0 +1,14 @@
+/**
+ * Barrel export for all vended plugins.
+ *
+ * Provides a single import path for consumers who want all built-in plugins:
+ * ```typescript
+ * import { AgentSkills, ContextOffloader, InMemoryStorage } from '@strands-agents/sdk/vended-plugins'
+ * ```
+ */
+
+export { Skill, AgentSkills } from './skills/index.js'
+export type { SkillConfig, AgentSkillsConfig, SkillSource } from './skills/index.js'
+
+export { ContextOffloader, InMemoryStorage, FileStorage, S3Storage } from './context-offloader/index.js'
+export type { ContextOffloaderConfig, Storage } from './context-offloader/index.js'

--- a/strands-ts/src/vended-plugins/index.ts
+++ b/strands-ts/src/vended-plugins/index.ts
@@ -7,8 +7,5 @@
  * ```
  */
 
-export { Skill, AgentSkills } from './skills/index.js'
-export type { SkillConfig, AgentSkillsConfig, SkillSource } from './skills/index.js'
-
-export { ContextOffloader, InMemoryStorage, FileStorage, S3Storage } from './context-offloader/index.js'
-export type { ContextOffloaderConfig, Storage } from './context-offloader/index.js'
+export * from './skills/index.js'
+export * from './context-offloader/index.js'

--- a/strands-ts/src/vended-tools/index.ts
+++ b/strands-ts/src/vended-tools/index.ts
@@ -1,0 +1,24 @@
+/**
+ * Barrel export for all vended tools.
+ *
+ * Provides a single import path for consumers who want all built-in tools:
+ * ```typescript
+ * import { bash, fileEditor, httpRequest, notebook } from '@strands-agents/sdk/vended-tools'
+ * ```
+ *
+ * Note: This module requires a Node.js environment because the `bash` tool
+ * imports `child_process`. For browser-compatible usage, import individual
+ * tools via their subpath exports (e.g., `@strands-agents/sdk/vended-tools/notebook`).
+ */
+
+export { bash, BashTimeoutError, BashSessionError } from './bash/index.js'
+export type { BashInput, BashOutput, ExecuteInput, RestartInput } from './bash/index.js'
+
+export { fileEditor } from './file-editor/index.js'
+export type { FileEditorInput, FileEditorOptions, IFileReader } from './file-editor/index.js'
+
+export { httpRequest } from './http-request/index.js'
+export type { HttpRequestInput, HttpRequestOutput } from './http-request/index.js'
+
+export { notebook } from './notebook/index.js'
+export type { NotebookState, NotebookInput } from './notebook/index.js'

--- a/strands-ts/src/vended-tools/index.ts
+++ b/strands-ts/src/vended-tools/index.ts
@@ -11,14 +11,7 @@
  * tools via their subpath exports (e.g., `@strands-agents/sdk/vended-tools/notebook`).
  */
 
-export { bash, BashTimeoutError, BashSessionError } from './bash/index.js'
-export type { BashInput, BashOutput, ExecuteInput, RestartInput } from './bash/index.js'
-
-export { fileEditor } from './file-editor/index.js'
-export type { FileEditorInput, FileEditorOptions, IFileReader } from './file-editor/index.js'
-
-export { httpRequest } from './http-request/index.js'
-export type { HttpRequestInput, HttpRequestOutput } from './http-request/index.js'
-
-export { notebook } from './notebook/index.js'
-export type { NotebookState, NotebookInput } from './notebook/index.js'
+export * from './bash/index.js'
+export * from './file-editor/index.js'
+export * from './http-request/index.js'
+export * from './notebook/index.js'

--- a/strands-ts/test/packages/cjs-module/cjs.js
+++ b/strands-ts/test/packages/cjs-module/cjs.js
@@ -12,6 +12,19 @@ async function main() {
   const { httpRequest } = await import('@strands-agents/sdk/vended-tools/http-request')
   const { bash } = await import('@strands-agents/sdk/vended-tools/bash')
 
+  const {
+    bash: barrelBash,
+    fileEditor: barrelFileEditor,
+    httpRequest: barrelHttpRequest,
+    notebook: barrelNotebook,
+  } = await import('@strands-agents/sdk/vended-tools')
+
+  const {
+    AgentSkills,
+    ContextOffloader,
+    InMemoryStorage,
+  } = await import('@strands-agents/sdk/vended-plugins')
+
   const { BedrockModel: BedrockFromSubpath } = await import('@strands-agents/sdk/models/bedrock')
   const { OpenAIModel } = await import('@strands-agents/sdk/models/openai')
   const { AnthropicModel } = await import('@strands-agents/sdk/models/anthropic')
@@ -67,6 +80,18 @@ async function main() {
     throw new Error('BedrockModel from subpath should match main export')
   }
   console.log('✓ Model subpath exports verified')
+
+  // Verify barrel exports match individual subpath exports
+  if (barrelBash !== bash || barrelFileEditor !== fileEditor || barrelHttpRequest !== httpRequest || barrelNotebook !== notebook) {
+    throw new Error('Barrel vended-tools exports do not match individual subpath exports')
+  }
+  console.log('✓ Barrel vended-tools exports verified')
+
+  // Verify barrel vended-plugins exports are constructible
+  if (typeof AgentSkills !== 'function' || typeof ContextOffloader !== 'function' || typeof InMemoryStorage !== 'function') {
+    throw new Error('Barrel vended-plugins exports are not constructible')
+  }
+  console.log('✓ Barrel vended-plugins exports verified')
 
   // Reference remaining imports so static analysis doesn't flag them unused.
   void OpenAIModel

--- a/strands-ts/test/packages/esm-module/esm.js
+++ b/strands-ts/test/packages/esm-module/esm.js
@@ -10,6 +10,19 @@ import { fileEditor } from '@strands-agents/sdk/vended-tools/file-editor'
 import { httpRequest } from '@strands-agents/sdk/vended-tools/http-request'
 import { bash } from '@strands-agents/sdk/vended-tools/bash'
 
+import {
+  bash as barrelBash,
+  fileEditor as barrelFileEditor,
+  httpRequest as barrelHttpRequest,
+  notebook as barrelNotebook,
+} from '@strands-agents/sdk/vended-tools'
+
+import {
+  AgentSkills,
+  ContextOffloader,
+  InMemoryStorage,
+} from '@strands-agents/sdk/vended-plugins'
+
 // Verify model subpath exports
 import { BedrockModel as BedrockFromSubpath } from '@strands-agents/sdk/models/bedrock'
 import { OpenAIModel } from '@strands-agents/sdk/models/openai'
@@ -110,3 +123,15 @@ if (BedrockFromSubpath !== BedrockModel) {
   throw new Error('BedrockModel from subpath should match main export')
 }
 console.log('✓ Model subpath exports verified')
+
+// Verify barrel exports match individual subpath exports
+if (barrelBash !== bash || barrelFileEditor !== fileEditor || barrelHttpRequest !== httpRequest || barrelNotebook !== notebook) {
+  throw new Error('Barrel vended-tools exports do not match individual subpath exports')
+}
+console.log('✓ Barrel vended-tools exports verified')
+
+// Verify barrel vended-plugins exports are constructible
+if (typeof AgentSkills !== 'function' || typeof ContextOffloader !== 'function' || typeof InMemoryStorage !== 'function') {
+  throw new Error('Barrel vended-plugins exports are not constructible')
+}
+console.log('✓ Barrel vended-plugins exports verified')

--- a/strands-ts/test/packages/npm-pack/verify.ts
+++ b/strands-ts/test/packages/npm-pack/verify.ts
@@ -27,6 +27,19 @@ import { fileEditor } from '@strands-agents/sdk/vended-tools/file-editor'
 import { httpRequest } from '@strands-agents/sdk/vended-tools/http-request'
 import { bash } from '@strands-agents/sdk/vended-tools/bash'
 
+import {
+  bash as barrelBash,
+  fileEditor as barrelFileEditor,
+  httpRequest as barrelHttpRequest,
+  notebook as barrelNotebook,
+} from '@strands-agents/sdk/vended-tools'
+
+import {
+  AgentSkills as BarrelAgentSkills,
+  ContextOffloader as BarrelContextOffloader,
+  InMemoryStorage as BarrelInMemoryStorage,
+} from '@strands-agents/sdk/vended-plugins'
+
 import { BedrockModel as BedrockFromSubpath } from '@strands-agents/sdk/models/bedrock'
 import { Graph, Swarm, MultiAgentState } from '@strands-agents/sdk/multiagent'
 import { AgentSkills } from '@strands-agents/sdk/vended-plugins/skills'
@@ -115,5 +128,13 @@ if (!(ctxErr instanceof Error)) {
 
 void AgentResult
 console.log('[pack-test] Error + result types importable')
+
+if (barrelBash !== bash || barrelFileEditor !== fileEditor || barrelHttpRequest !== httpRequest || barrelNotebook !== notebook) {
+  throw new Error('Barrel vended-tools exports do not match individual subpath exports')
+}
+if (BarrelAgentSkills !== AgentSkills || BarrelContextOffloader !== ContextOffloader || BarrelInMemoryStorage !== InMemoryStorage) {
+  throw new Error('Barrel vended-plugins exports do not match individual subpath exports')
+}
+console.log('[pack-test] barrel exports match individual subpath exports')
 
 console.log('[pack-test] OK')


### PR DESCRIPTION
## Motivation

Consumers currently need separate imports for each vended tool and plugin, which is verbose when using multiple tools together. A barrel export at `@strands-agents/sdk/vended-tools` and `@strands-agents/sdk/vended-plugins` enables single-line imports for the common case while preserving individual subpath exports for selective usage.

Resolves: #49

## Public API Changes

Two new subpath exports are now available:

```typescript
// Before: separate imports per tool
import { bash } from '@strands-agents/sdk/vended-tools/bash'
import { fileEditor } from '@strands-agents/sdk/vended-tools/file-editor'
import { httpRequest } from '@strands-agents/sdk/vended-tools/http-request'
import { notebook } from '@strands-agents/sdk/vended-tools/notebook'

// After: single barrel import
import { bash, fileEditor, httpRequest, notebook } from '@strands-agents/sdk/vended-tools'
```

```typescript
// Before: separate imports per plugin
import { AgentSkills } from '@strands-agents/sdk/vended-plugins/skills'
import { ContextOffloader, InMemoryStorage } from '@strands-agents/sdk/vended-plugins/context-offloader'

// After: single barrel import
import { AgentSkills, ContextOffloader, InMemoryStorage } from '@strands-agents/sdk/vended-plugins'
```

All type exports (e.g., `BashInput`, `SkillConfig`, `Storage`) are also available through the barrel. Existing individual subpath imports continue to work unchanged — the barrel is purely additive.

The `vended-tools` barrel requires Node.js because `bash` imports `child_process`. This is acceptable since the barrel is a separate subpath (not added to the main `src/index.ts`) and consumers who import it are inherently in a Node.js context.